### PR TITLE
Handle OUT_DIR being relative to the top directory

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -21,7 +21,7 @@ LOCAL_PACKAGE_NAME := FakeStore
 
 fakestore_root  := $(LOCAL_PATH)
 fakestore_dir   := fake-store
-fakestore_out   := $(OUT_DIR)/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
+fakestore_out   := $(realpath $(OUT_DIR))/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
 fakestore_build := $(fakestore_root)/$(fakestore_dir)/build
 fakestore_apk   := build/outputs/apk/fake-store-release-unsigned.apk
 


### PR DESCRIPTION
The symlink created by Android.mk is in LOCAL_PATH, while
OUT_DIR may be relative to the top directory (AOSP 8.0),
causing the symlink to point at a wrong location.

Make sure the symlink points at an absolute path.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>