### PR TITLE
Updating FakeStore versions and enabling direct ROM build

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -23,7 +23,7 @@ fakestore_root  := $(LOCAL_PATH)
 fakestore_dir   := fake-store
 fakestore_out   := $(OUT_DIR)/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
 fakestore_build := $(fakestore_root)/$(fakestore_dir)/build
-fakestore_apk   := build/outputs/apk/fake-store-release-unsigned.apk
+fakestore_apk   := build/outputs/apk/release/fake-store-release-unsigned.apk
 
 $(fakestore_root)/$(fakestore_dir)/$(fakestore_apk):
 	rm -Rf $(fakestore_build)

--- a/Android.mk
+++ b/Android.mk
@@ -34,6 +34,7 @@ $(fakestore_root)/$(fakestore_dir)/$(fakestore_apk):
 	cd $(fakestore_root)/$(fakestore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
+LOCAL_PRIVILEGED_MODULE := true
 LOCAL_SRC_FILES := $(fakestore_dir)/$(fakestore_apk)
 LOCAL_MODULE_CLASS := APPS
 LOCAL_MODULE_SUFFIX := $(COMMON_ANDROID_PACKAGE_SUFFIX)

--- a/Android.mk
+++ b/Android.mk
@@ -21,17 +21,20 @@ LOCAL_PACKAGE_NAME := FakeStore
 
 fakestore_root  := $(LOCAL_PATH)
 fakestore_dir   := fake-store
-fakestore_out   := $(OUT_DIR)/target/common/obj/APPS/$(LOCAL_MODULE)_intermediates
+fakestore_out   := $(TARGET_COMMON_OUT_ROOT)/obj/APPS/$(LOCAL_MODULE)_intermediates
 fakestore_build := $(fakestore_root)/$(fakestore_dir)/build
 fakestore_apk   := build/outputs/apk/release/fake-store-release-unsigned.apk
 
-$(fakestore_root)/$(fakestore_dir)/$(fakestore_apk):
-	rm -Rf $(fakestore_build)
-	mkdir -p $(fakestore_out)
-	ln -s $(fakestore_out) $(fakestore_build)
-	echo "sdk.dir=$(ANDROID_HOME)" > $(fakestore_root)/local.properties
-	cd $(fakestore_root) && git submodule update --recursive --init
-	cd $(fakestore_root)/$(fakestore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
+.PHONY: preps_fs
+preps_fs:
+	rm -rf $(fakestore_build); \
+	mkdir -p $(ANDROID_BUILD_TOP)/$(fakestore_out); \
+	ln -s $(ANDROID_BUILD_TOP)/$(fakestore_out)/ $(ANDROID_BUILD_TOP)/$(fakestore_build)
+
+$(fakestore_root)/$(fakestore_dir)/$(fakestore_apk): preps_fs
+	echo "sdk.dir=$(ANDROID_HOME)" > $(fakestore_root)/local.properties; \
+	cd $(fakestore_root) && git submodule update --recursive --init; \
+	cd $(fakestore_dir) && JAVA_TOOL_OPTIONS="$(JAVA_TOOL_OPTIONS) -Dfile.encoding=UTF8" ../gradlew assembleRelease
 
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,22 +17,22 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 
 allprojects {
     apply plugin: 'idea'
-    ext.androidBuildVersionTools = "24.0.3"
-    ext.isReleaseVersion = false
+    ext.androidBuildVersionTools = "27.0.3"
 }
 
-def androidCompileSdk() { return 24 }
+def androidCompileSdk() { return 27 }
 
-def androidTargetSdk() { return 24 }
+def androidTargetSdk() { return 27 }
 
 def androidMinSdk() { return 9 }
 
@@ -55,11 +55,12 @@ subprojects {
     group = 'org.microg'
     repositories {
         jcenter()
+        google()
     }
 
     tasks.withType(JavaCompile) {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/fake-store/build.gradle
+++ b/fake-store/build.gradle
@@ -46,7 +46,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_6
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/fake-store/src/main/AndroidManifest.xml
+++ b/fake-store/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:minSdkVersion="10"
         android:targetSdkVersion="23"/>
 
+    <permission android:name="com.android.vending.CHECK_LICENSE" android:protectionLevel="normal"/>
     <uses-permission android:name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
     <application
         android:icon="@drawable/icon"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip


### PR DESCRIPTION
I updated the versions according to the rest of the project and adapted a few things to allow for direct build within a ROM. I tested this with a Sony AOSP build and was using it for a while without errors.
Also included latest PRs.

Would be happy to have this included in the microg repository (e.g. as version 0.0.3?), as I then can close the fork.

Regular build should be unaffected, at least it is in my setup.

@mar-v-in I will send PRs for GmsCore, etc. as well, most of them to adapt to direct ROM build. I think it would be great if other forks could merge back in the microg repository as well. What do you think?