### PR TITLE
Added Russian translation

### DIFF
--- a/fake-store/src/main/res/values-ru/strings.xml
+++ b/fake-store/src/main/res/values-ru/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2014 μg Project Team
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="app_name">Пустой маркет</string>
+</resources>


### PR DESCRIPTION
Even though only the package name is localized as the only possible string for internationalization, my GmsCore translation variant and my microg.org translation pull requests mention this component by this name in Russian. A local name would increase user-friendliness.