### PR TITLE
Implement minimal LicensingService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,14 @@
  */
 
 buildscript {
+    ext.kotlin_version = '1.6.21'
     repositories {
         jcenter()
         google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/fake-store/build.gradle
+++ b/fake-store/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 String getMyVersionName() {
     def stdout = new ByteArrayOutputStream()
@@ -53,4 +54,10 @@ android {
 
 if (file('user.gradle').exists()) {
     apply from: 'user.gradle'
+}
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/fake-store/src/main/AndroidManifest.xml
+++ b/fake-store/src/main/AndroidManifest.xml
@@ -39,5 +39,13 @@
                 <action android:name="com.android.vending.billing.InAppBillingService.BIND" />
             </intent-filter>
         </service>
+
+        <service
+            android:name="com.android.vending.licensing.LicensingService" >
+            <intent-filter>
+                <action android:name="com.android.vending.licensing.ILicensingService" />
+            </intent-filter>
+        </service>
+
     </application>
 </manifest>

--- a/fake-store/src/main/aidl/com/android/vending/licensing/ILicenseResultListener.aidl
+++ b/fake-store/src/main/aidl/com/android/vending/licensing/ILicenseResultListener.aidl
@@ -1,0 +1,6 @@
+package com.android.vending.licensing;
+
+interface ILicenseResultListener {
+
+   void allow(int i);
+}

--- a/fake-store/src/main/aidl/com/android/vending/licensing/ILicensingService.aidl
+++ b/fake-store/src/main/aidl/com/android/vending/licensing/ILicensingService.aidl
@@ -1,0 +1,8 @@
+package com.android.vending.licensing;
+
+import com.android.vending.licensing.ILicenseResultListener;
+
+interface ILicensingService {
+
+    void checkLicense(long someLong, String someString, in ILicenseResultListener listener);
+}

--- a/fake-store/src/main/java/com/android/vending/licensing/LicensingService.kt
+++ b/fake-store/src/main/java/com/android/vending/licensing/LicensingService.kt
@@ -1,0 +1,27 @@
+package com.android.vending.licensing
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class LicensingService : Service() {
+
+    companion object {
+        const val LICENSED_OLD_KEY = 2
+    }
+
+    private val mServiceInterface = object : ILicensingService.Stub() {
+        override fun checkLicense(
+            someLong: Long,
+            someString: String,
+            listener: ILicenseResultListener
+        ) {
+            // Answer allow for each request
+            listener.allow(LICENSED_OLD_KEY)
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        return mServiceInterface
+    }
+}


### PR DESCRIPTION
Implemented ILicensingService & ILicenseResultListener interfaces with the minimal logic.

For now, we always answer the listener that the license result is correct.