### PR TITLE
Implement SplitInstallService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,14 @@
  */
 
 buildscript {
+    ext.kotlin_version = '1.6.21'
     repositories {
         jcenter()
         google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/fake-store/build.gradle
+++ b/fake-store/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 String getMyVersionName() {
     def stdout = new ByteArrayOutputStream()
@@ -53,4 +54,11 @@ android {
 
 if (file('user.gradle').exists()) {
     apply from: 'user.gradle'
+}
+repositories {
+    mavenCentral()
+}
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
 }

--- a/fake-store/src/main/AndroidManifest.xml
+++ b/fake-store/src/main/AndroidManifest.xml
@@ -39,5 +39,12 @@
                 <action android:name="com.android.vending.billing.InAppBillingService.BIND" />
             </intent-filter>
         </service>
+
+        <service
+            android:name="com.android.vending.SplitInstallService" >
+            <intent-filter>
+                <action android:name="com.google.android.play.core.splitinstall.BIND_SPLIT_INSTALL_SERVICE" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/fake-store/src/main/aidl/com/dummy/store/IDummyStoreSplitInstallService.aidl
+++ b/fake-store/src/main/aidl/com/dummy/store/IDummyStoreSplitInstallService.aidl
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dummy.store;
+
+interface IDummyStoreSplitInstallService {
+    void installSplitModule(String packageName, String moduleName);
+}

--- a/fake-store/src/main/aidl/com/google/android/play/core/splitinstall/protocol/ISplitInstallService.aidl
+++ b/fake-store/src/main/aidl/com/google/android/play/core/splitinstall/protocol/ISplitInstallService.aidl
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.play.core.splitinstall.protocol;
+
+import com.google.android.play.core.splitinstall.protocol.ISplitInstallServiceCallback;
+
+interface ISplitInstallService {
+
+    // Method not identified yet
+    void a();
+
+    void startInstall(String str, in List<Bundle> list, in Bundle bundle, in ISplitInstallServiceCallback callback);
+
+    // Method not identified yet
+    void c(String str);
+
+    // Method not identified yet
+    void d(String str);
+
+    // Method not identified yet
+    void e(String str);
+
+    void getSessionStates(String str, in ISplitInstallServiceCallback callback);
+
+    // Method not identified yet
+    void g(String str);
+
+    // Method not identified yet
+    void h(String str, in ISplitInstallServiceCallback callback);
+
+    // Method not identified yet
+    void i(String str);
+
+    // Method not identified yet
+    void j(String str);
+
+    // Method not identified yet
+    void k(String str);
+
+    // Method not identified yet
+    void l(String str);
+
+    // Method not identified yet
+    void m(String str);
+}

--- a/fake-store/src/main/aidl/com/google/android/play/core/splitinstall/protocol/ISplitInstallServiceCallback.aidl
+++ b/fake-store/src/main/aidl/com/google/android/play/core/splitinstall/protocol/ISplitInstallServiceCallback.aidl
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.play.core.splitinstall.protocol;
+
+import android.os.Bundle;
+
+interface ISplitInstallServiceCallback {
+
+    void onStartInstall(int i, in Bundle bundle);
+
+    // Method not identified yet
+    void b();
+
+    void onCompleteInstall(int i);
+
+    void onCancelInstall(int i, in Bundle bundle);
+
+    void onGetSession(int i, in Bundle bundle);
+
+    void onError(in Bundle bundle);
+
+    void onGetSessionStates(in List<Bundle> list);
+
+    void onDeferredUninstall(in Bundle bundle);
+
+    void onDeferredInstall(in Bundle bundle);
+
+    void onGetSplitsForAppUpdate();
+
+    void onCompleteInstallForAppUpdate();
+
+    void onDeferredLanguageInstall();
+}

--- a/fake-store/src/main/java/com/android/vending/SplitInstallService.kt
+++ b/fake-store/src/main/java/com/android/vending/SplitInstallService.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.vending
+
+import android.app.Service
+import android.content.Intent
+import android.os.Bundle
+import android.os.IBinder
+import android.util.Log
+import com.android.vending.splitinstall.SplitInstaller
+import com.android.vending.splitinstall.SplitInstallerFactory
+import com.android.vending.splitinstall.SplitInstallerType
+import com.google.android.play.core.splitinstall.protocol.ISplitInstallService
+import com.google.android.play.core.splitinstall.protocol.ISplitInstallServiceCallback
+
+class SplitInstallService : Service() {
+
+    companion object {
+        const val TAG = "SplitInstallService"
+    }
+
+    private lateinit var mSplitInstaller: SplitInstaller
+
+    override fun onCreate() {
+        super.onCreate()
+
+        mSplitInstaller = SplitInstallerFactory.createSplitInstaller(
+            applicationContext,
+            SplitInstallerType.DummyStoreSplitInstaller
+        )
+
+        mSplitInstaller.initialize()
+    }
+
+    override fun onBind(p0: Intent?): IBinder {
+        return mServiceInterface
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mSplitInstaller.destroy()
+    }
+
+    private var mServiceInterface = object : ISplitInstallService.Stub() {
+
+        override fun a() {
+            Log.d(TAG, "a")
+        }
+
+        override fun startInstall(
+            packageName: String,
+            list: List<Bundle>,
+            bundle: Bundle,
+            callback: ISplitInstallServiceCallback
+        ) {
+            for (element in list) {
+                mSplitInstaller.install(packageName, element.get("module_name").toString())
+            }
+        }
+
+        override fun c(str: String?) {
+            Log.d(TAG, "c")
+        }
+
+        override fun d(str: String?) {
+            Log.d(TAG, "d")
+        }
+
+        override fun e(str: String?) {
+            Log.d(TAG, "e")
+        }
+
+        override fun getSessionStates(str: String, callback: ISplitInstallServiceCallback) {
+            Log.d(TAG, "onGetSessionStates")
+            callback.onGetSessionStates(arrayListOf<Bundle>())
+        }
+
+        override fun g(str: String?) {
+            Log.d(TAG, "g")
+        }
+
+        override fun h(str: String?, callback: ISplitInstallServiceCallback?) {
+            Log.d(TAG, "h $str $callback")
+        }
+
+        override fun i(str: String?) {
+            Log.d(TAG, "i")
+        }
+
+        override fun j(str: String?) {
+            Log.d(TAG, "j")
+        }
+
+        override fun k(str: String?) {
+            Log.d(TAG, "k")
+        }
+
+        override fun l(str: String?) {
+            Log.d(TAG, "l")
+        }
+
+        override fun m(str: String?) {
+            Log.d(TAG, "m")
+        }
+    }
+}

--- a/fake-store/src/main/java/com/android/vending/splitinstall/SplitInstallErrorCode.kt
+++ b/fake-store/src/main/java/com/android/vending/splitinstall/SplitInstallErrorCode.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.vending.splitinstall
+
+interface SplitInstallErrorCode {
+    companion object {
+        const val API_NOT_AVAILABLE = -5
+    }
+}

--- a/fake-store/src/main/java/com/android/vending/splitinstall/SplitInstaller.kt
+++ b/fake-store/src/main/java/com/android/vending/splitinstall/SplitInstaller.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.vending.splitinstall
+
+import android.content.Context
+import com.android.vending.splitinstall.installer.DummyStoreSplitInstaller
+
+interface SplitInstaller {
+    fun initialize()
+    fun install(packageName: String, moduleName: String)
+    fun destroy()
+}
+
+enum class SplitInstallerType { DummyStoreSplitInstaller }
+
+object SplitInstallerFactory {
+    fun createSplitInstaller(context: Context, type: SplitInstallerType): SplitInstaller {
+        when (type) {
+            SplitInstallerType.DummyStoreSplitInstaller ->
+                return DummyStoreSplitInstaller(context)
+            else -> throw IllegalArgumentException("Unknown SplitInstallerType")
+        }
+    }
+}

--- a/fake-store/src/main/java/com/android/vending/splitinstall/installer/DummyStoreSplitInstaller.kt
+++ b/fake-store/src/main/java/com/android/vending/splitinstall/installer/DummyStoreSplitInstaller.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2022 microG Project Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.vending.splitinstall.installer
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import com.android.vending.splitinstall.SplitInstaller
+import com.dummy.store.IDummyStoreSplitInstallService
+
+class DummyStoreSplitInstaller(
+    private val context: Context
+) : SplitInstaller {
+
+    companion object {
+        private val ON_DEMAND_DELIVERY_SERVICE_COMPONENT =
+            ComponentName("com.dummy.store", "com.dummy.store.splitinstall.SplitInstallService")
+    }
+
+    private var service: IDummyStoreSplitInstallService? = null
+    private val moduleList = ArrayList<InstallModule>()
+
+    private val serviceConnection = object : ServiceConnection {
+        override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
+            service = IDummyStoreSplitInstallService.Stub.asInterface(binder)
+            installWaitingModules()
+        }
+
+        override fun onServiceDisconnected(componentName: ComponentName) {
+            service = null
+        }
+    }
+
+    override fun initialize() {
+        val intent = Intent().apply {
+            component = ON_DEMAND_DELIVERY_SERVICE_COMPONENT
+        }
+
+        context.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
+    }
+
+    override fun destroy() {
+        context.unbindService(serviceConnection)
+    }
+
+    override fun install(packageName: String, moduleName: String) {
+        if (service == null) {
+            moduleList.add(InstallModule(packageName, moduleName))
+        }
+
+        service?.installSplitModule(packageName, moduleName)
+    }
+
+    private fun installWaitingModules() {
+        val iterator = moduleList.iterator()
+        while (iterator.hasNext()) {
+            val module = iterator.next()
+            service?.installSplitModule(module.packageName, module.moduleName)
+            iterator.remove()
+        }
+    }
+
+    private data class InstallModule(val packageName: String, val moduleName: String)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
When a 3rd party app wants to install a split APK, the application tries to bind to a SplitInstallService through the SplitInstallManager part of the Google Play Feature Delivery Library.

The implementation of SplitInstallService allows us to catch the install requests coming from the 3rd party app and handle them.

As an example, DummyStoreSplitInstaller binds to an external com.dummy.store.splitinstall.SplitInstallService service which is able to retrieve the split APKs from the com.dummy.store.