### PR TITLE
Simplify signing procedure, now it get values automatically from keystore.properties if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 user.gradle
 local.properties
 *.iml
+keystore.properties
+keystore.jks

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,39 @@ def versionName() {
     return stdout.toString().trim().substring(1)
 }
 
+private void configureSigning(def android, File keystorePropsFile)
+{
+    if (!keystorePropsFile.exists()) return
+    if (android == null) throw new GradleException('android is null inside configureSigning()')
+
+    println 'Signed build'
+
+    Properties keystoreProps = new Properties()
+    keystoreProps.load(new FileInputStream(keystorePropsFile))
+
+    String keyStorePassword
+    boolean fallbackToEnv = keystoreProps.containsKey('fallbackToEnv') && keystoreProps['fallbackToEnv'] == 'true'
+
+    if (keystoreProps.containsKey('keyStorePassword'))
+        keyStorePassword = keystoreProps['keyStorePassword']
+    else if (fallbackToEnv)
+        keyStorePassword = System.getenv('KEYSTORE_PASSWORD')
+
+    if (keyStorePassword == null || keyStorePassword.isEmpty())
+        throw new InvalidUserDataException('Keystore password is empty')
+
+    android.signingConfigs {
+        config {
+            storeFile = rootProject.file(keystoreProps['storeFile'])
+            storePassword = keyStorePassword
+            keyAlias = keystoreProps['keyAlias']
+            keyPassword = keyStorePassword
+        }
+    }
+
+    android.buildTypes.release.signingConfig android.signingConfigs.config
+}
+
 allprojects {
     apply plugin: 'idea'
     version = versionName()
@@ -47,4 +80,3 @@ subprojects {
         google()
     }
 }
-

--- a/fake-store/build.gradle
+++ b/fake-store/build.gradle
@@ -27,6 +27,8 @@ android {
     }
 }
 
+configureSigning(android, rootProject.file('keystore.properties'))
+
 if (file('user.gradle').exists()) {
     apply from: 'user.gradle'
 }


### PR DESCRIPTION
@mar-v-in

Simplify signing procedure, now it get values automatically from keystore.properties if present;
in addition it can optionally get the Keystore password from KEYSTORE_PASSWORD env variable.

**INSTRUCTIONS**
Just place the keystore file `keystore.jks` and a file called `keystore.properties` in the main folder of the repo (on your local PC only).
If the file `keystore.properties` is missing it will compile an unsigned build.

Example of `keystore.properties`:
```
storeFile=keystore.jks
keyAlias=my_alias
keyStorePassword=my_password
```

Instead to use the password from env the `keystore.properties` should be:
```
storeFile=keystore.jks
keyAlias=my_alias
fallbackToEnv=true
```
and you must set the the env var `KEYSTORE_PASSWORD`.